### PR TITLE
Add ability to specify accept types

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,27 @@ HTTP verbs
     'DELETE'
     webshell> ^D
 
+Accept Types
+------------
+
+    webshell> $_.get("http://localhost:3000/echoaccept")
+    GET http://localhost:3000/echoaccept
+    HTTP 200 http://localhost:3000/echoaccept
+    webshell> $_.raw
+    'application/json, */*'
+    webshell> $_.acceptTypes = ['text/plain','text/html']
+    [ 'text/plain', 'text/html' ]
+    webshell> $_.get("http://localhost:3000/echoaccept")
+    GET http://localhost:3000/echoaccept
+    HTTP 200 http://localhost:3000/echoaccept
+    webshell> $_.raw
+    'text/plain, text/html'
+    webshell> $_.acceptTypes.shift()
+    'text/plain'
+    webshell> $_.get("http://localhost:3000/echoaccept")
+    GET http://localhost:3000/echoaccept
+    HTTP 200 http://localhost:3000/echoaccept
+    webshell> $_.raw
+    'text/html'
+    webshell> ^D
+

--- a/shell.js
+++ b/shell.js
@@ -43,7 +43,7 @@ var $_ = {
   },
   cookies: cookies,
   toolbox: {},
-  acceptTypes: ['wapplication/json', '*/*'],
+  acceptTypes: ['application/json', '*/*'],
   evalFile: function (filename) {
     eval("var s = " + fs.readFileSync(filename));
     return s;

--- a/shell.js
+++ b/shell.js
@@ -43,6 +43,7 @@ var $_ = {
   },
   cookies: cookies,
   toolbox: {},
+  acceptTypes: ['wapplication/json', '*/*'],
   evalFile: function (filename) {
     eval("var s = " + fs.readFileSync(filename));
     return s;
@@ -227,7 +228,7 @@ function WebShell(stream) {
     } else if (url.protocol === 'http:' && url.port !== 80) {
       hostHeader += ":" + url.port;
     }
-    var headers = {'Host': hostHeader, 'User-Agent': 'webshell (node.js)', 'Accept': 'application/json, */*'};
+    var headers = {'Host': hostHeader, 'User-Agent': 'webshell (node.js)', 'Accept': $_.acceptTypes.join(', ')};
     if (url.auth) {
       headers['Authorization'] = 'Basic ' + base64Encode(url.auth);
     }
@@ -267,7 +268,7 @@ function WebShell(stream) {
 
     // merge in $_.requestHeaders
     _.each($_.requestHeaders, function(v, k) {
-      if (k.toLowerCase() != 'host') { // host is provided by makeHeaders()
+      if (k.toLowerCase() != 'host' && k.toLowerCase() != 'accept') { // host and accept are  provided by makeHeaders()
         headers[k] = v;
       }
     });


### PR DESCRIPTION
I made a change to my fork to allow overriding the default "accept" header content types. $_ now has the array "acceptTypes" which defaults to what was previously hardcoded in makeHeaders.

It's a minor change but pretty handy, README is updated too. Tested with saving loading contexts too.

Thanks for writing webshell btw, it has replaced about 95% of my curl use.
