### PR TITLE
First time users asplode!

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -310,7 +310,7 @@ function WebShell(stream) {
     result = new ResultHolder(verb, urlStr);
 
     var u = parseURL(urlStr);
-    var prevU = parseURL($_.previousUrl);
+    var prevU = parseURL($_.previousUrl || 'http://example.com');
 
     // check for prev host (and no host on this req) == relative request
     if (!u.protocol && !u.hostname) {


### PR DESCRIPTION
Hey Sean,

I loved you presentation yesterday! It was one of those where you see a pain that you've been having for years just dissolve before your eyes :-)

I tried webshell this morning and had an exception because I had no $_.previousUrl. So anything I tried failed.

I made an simple (and temporary) fix that works well if the first url you access is properly specified, but is a little wonky if you try to take a shortcut. Here's what I mean:

Shortcut:
Could not load context: _previous
webshell> GET google.com
HTTP 404 http://example.com/google.com

rm -rf ~/.webshellrc 

No shortcut:
Could not load context: _previous
webshell> GET http://google.com
HTTP 301 http://google.com/

So it can be done better, but this fix will at least let excited attendees from yesterday try it out without a problem ;-)

Thanks for your presentation and for this tool!
Cheers,

webmat
