### PR TITLE
Don't override user specified authorization header.

### DIFF
--- a/wshttp.js
+++ b/wshttp.js
@@ -240,11 +240,13 @@ WsHttp.prototype = {
       delete headers['content-length'];
     }
 
-    this.calculateAuth(u);
-    delete(u.auth);
-    delete(headers.authorization);
-    if (!doAuth && undefined !== this.$_.auth && (this.$_.auth.rerequested)) {
-      doAuth = this.$_.auth.rerequested;
+    if (!headers['authorization']) {
+      this.calculateAuth(u);
+      delete(u.auth);
+      delete(headers.authorization);
+      if (!doAuth && undefined !== this.$_.auth && (this.$_.auth.rerequested)) {
+        doAuth = this.$_.auth.rerequested;
+      }
     }
 
     var reqPath = u.pathname + (undefined === u.search ? '' : u.search);


### PR DESCRIPTION
Some REST API's require a custom authorization header to be specified. If this header is specified, don't override it when making the request.
