### PR TITLE
Update for change to node

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ tasty morsels.
 Requirements
 ----------------------------
 
-* [Node.js](http://nodejs.org/) >=0.4.0
+* [Node.js](http://nodejs.org/) >=0.4.4
 * [Hashlib](https://github.com/brainfucker/hashlib) >=1.0.0
 
 Installation

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "url": "https://github.com/fictivekin/webshell.git"
   },
   "engines": { "node": ">=0.4.0" },
-  "dependencies": { "hashlib": ">=1.0.0" },
+  "dependencies": { "hashlib": ">=1.0.0", "qs": "" },
   "bin": { "webshell": "./shell.js" }
 }

--- a/wshttp.js
+++ b/wshttp.js
@@ -8,7 +8,7 @@ var _ = require('underscore')._,
     url = require('url'),
     cookies = require('cookies'),
     stylize = require('colors').stylize,
-    querystring = require('querystring'),
+    querystring = require('qs'),
     hashlib = require('hashlib'),
     wsutil = require('wsutil');
 

--- a/wsrepl.js
+++ b/wsrepl.js
@@ -25,7 +25,7 @@ repl.REPLServer.prototype.outputAndPrompt = function (msg) {
 // NOTE: .complete can be dumped if/when this is pulled to ryah/node:
 // http://github.com/scoates/node/commit/44e8ebeee95600d571e3d316db8df1147c4da828
 
-var Script = process.binding('evals').Script;
+var Script = process.binding('evals').NodeScript;
 var evalcx = Script.runInContext;
 
 /**


### PR DESCRIPTION
In node 0.4.4 Script was changed to NodeScript to avoid conflict with
V8's Script class. See
https://github.com/joyent/node/commit/75db1995b6529cb71513a45299e2ba742e7afde9

node is now at 0.6.0 (stable).
