### PR TITLE
Use the qs module instead of node's querystring.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "url": "https://github.com/fictivekin/webshell.git"
   },
   "engines": { "node": ">=0.4.0" },
-  "dependencies": { "hashlib": ">=1.0.0" },
+  "dependencies": { "hashlib": ">=1.0.0", "qs": "" },
   "bin": { "webshell": "./shell.js" }
 }

--- a/wshttp.js
+++ b/wshttp.js
@@ -8,7 +8,7 @@ var _ = require('underscore')._,
     url = require('url'),
     cookies = require('cookies'),
     stylize = require('colors').stylize,
-    querystring = require('querystring'),
+    querystring = require('qs'),
     hashlib = require('hashlib'),
     wsutil = require('wsutil');
 


### PR DESCRIPTION
Node's querystring.stringify doesn't support nested objects (it was removed from 0.3.x), so nested
requestData was silently dropped by webshell. The qs module provides nested object support.
