### PR TITLE
Node 0.6 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ tasty morsels.
 Requirements
 ----------------------------
 
-* [Node.js](http://nodejs.org/) >=0.4.0
+* [Node.js](http://nodejs.org/) >=0.4.4
 * [Hashlib](https://github.com/brainfucker/hashlib) >=1.0.0
 
 Installation

--- a/cookies.js
+++ b/cookies.js
@@ -1,6 +1,6 @@
 var fs = require('fs'),
-    _ = require('underscore')._,
-    wsrc = require('wsrc');
+    _ = require('./underscore')._,
+    wsrc = require('./wsrc');
 
 var rc = wsrc.get();
 var cookieJar = rc.cookies || {};

--- a/env.js
+++ b/env.js
@@ -6,12 +6,12 @@
 
 var http = require('http'),
     url = require('url'),
-    _ = require('underscore')._;
+    _ = require('./underscore')._;
 var libxml;
 try {
   libxml = require('libxmljs');
 } catch (e) {
-  var stylize = require('colors').stylize;
+  var stylize = require('./colors').stylize;
   console.log(stylize("Unable to load libxmljs.  jQuery won't work!\n", 'yellow'));
   exports.DOMDocument = function(x) { };
   exports.window = {};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "url": "https://github.com/fictivekin/webshell.git"
   },
   "engines": { "node": ">=0.4.0" },
-  "dependencies": { "hashlib": ">=1.0.0" },
+  "dependencies": { "hashlib": ">=1.0.0", "qs": "" },
   "bin": { "webshell": "./shell.js" }
 }

--- a/shell.js
+++ b/shell.js
@@ -1,24 +1,22 @@
 #!/usr/bin/env node
-require.paths.unshift(__dirname + '/deps');
 var webshellVersion = '0.3-dev';
 
-require.paths.unshift(__dirname);
 var WebShell = {
   Util: {}
 };
 
 var util = require('util'),
     repl = require('repl'),
-    wsrepl = require('wsrepl'),
+    wsrepl = require('./wsrepl'),
     fs = require('fs'),
-    stylize = require('colors').stylize,
-    wsrc = require('wsrc'),
-    wsreadline = require('wsreadline'),
-    _ = require('underscore')._,
-    jquery = require('jquery'),
-    WsHttp = require('wshttp').WsHttp;
+    stylize = require('./colors').stylize,
+    wsrc = require('./wsrc'),
+    wsreadline = require('./wsreadline'),
+    _ = require('./underscore')._,
+    jquery = require('./jquery'),
+    WsHttp = require('./wshttp').WsHttp;
 
-_.extend(WebShell.Util, require('wsutil'));
+_.extend(WebShell.Util, require('./wsutil'));
 
 _.mixin({
   isJSON: function(headers) {
@@ -43,7 +41,7 @@ var $_ = {
   printResponse: true,
   postToRequestData: function (post) { return WebShell.Util.postToRequestData(this, post); },
   fileToRequestData: function (filename, encoding) { return WebShell.Util.fileToRequestData(this, filename, encoding); },
-  cookies: require('cookies'),
+  cookies: require('./cookies'),
   toolbox: {},
   evalFile: WebShell.Util.evalFile
 };

--- a/wshttp.js
+++ b/wshttp.js
@@ -2,15 +2,15 @@
 //   https://github.com/codehero/node-http-digest
 // "node-http-digest is in the public domain."
 
-var _ = require('underscore')._,
+var _ = require('./underscore')._,
     http = require('http'),
     https = require('https'),
     url = require('url'),
-    cookies = require('cookies'),
-    stylize = require('colors').stylize,
+    cookies = require('./cookies'),
+    stylize = require('./colors').stylize,
     querystring = require('qs'),
     hashlib = require('hashlib'),
-    wsutil = require('wsutil');
+    wsutil = require('./wsutil');
 
 var failCount = 0;
 var digestPersistent = {

--- a/wshttp.js
+++ b/wshttp.js
@@ -8,7 +8,7 @@ var _ = require('underscore')._,
     url = require('url'),
     cookies = require('cookies'),
     stylize = require('colors').stylize,
-    querystring = require('querystring'),
+    querystring = require('qs'),
     hashlib = require('hashlib'),
     wsutil = require('wsutil');
 

--- a/wsrc.js
+++ b/wsrc.js
@@ -1,7 +1,7 @@
 var fs = require('fs'),
-    stylize = require('colors').stylize,
-    wsutil = require('wsutil'),
-    _ = require('underscore')._;
+    stylize = require('./colors').stylize,
+    wsutil = require('./wsutil'),
+    _ = require('./underscore')._;
 
 var functionPrefix = '___WSFUNC___';
 

--- a/wsreadline.js
+++ b/wsreadline.js
@@ -5,9 +5,8 @@ var readline = require('readline'),
 
 module.exports = readline;
 
-var stdio = process.binding('stdio');
 var getCols = function() {
-  return tty.getWindowSize(stdio)[1];
+  return tty.getWindowSize(process.stdin);
 };
 
 readline.Interface.prototype.cursorToEnd = function() {
@@ -182,7 +181,7 @@ readline.Interface.prototype._prevLineParams = null;
 readline.Interface.prototype._refreshLine  = function () {
   if (this._closed) return;
 
-  stdio.setRawMode(true);
+  tty.setRawMode(true);
 
   var lineLen = this.line.length + this._promptLength;
   var rows = Math.floor(lineLen / getCols());

--- a/wsrepl.js
+++ b/wsrepl.js
@@ -25,7 +25,7 @@ repl.REPLServer.prototype.outputAndPrompt = function (msg) {
 // NOTE: .complete can be dumped if/when this is pulled to ryah/node:
 // http://github.com/scoates/node/commit/44e8ebeee95600d571e3d316db8df1147c4da828
 
-var Script = process.binding('evals').Script;
+var Script = process.binding('evals').NodeScript;
 var evalcx = Script.runInContext;
 
 /**

--- a/wsutil.js
+++ b/wsutil.js
@@ -1,11 +1,11 @@
 // vim: sw=2 ts=2 et
 var url = require('url'),
     util = require('util'),
-    stylize = require('colors').stylize,
+    stylize = require('./colors').stylize,
     querystring = require('querystring'),
     fs = require('fs'),
-    wsrc = require('wsrc'),
-    _ = require('underscore')._;
+    wsrc = require('./wsrc'),
+    _ = require('./underscore')._;
 
 exports.parseURL = function(urlStr, protocolHelp, previousUrl) {
   var u = url.parse(urlStr);


### PR DESCRIPTION
Incorporates https://github.com/fictivekin/webshell/pull/29 and https://github.com/fictivekin/webshell/pull/29.

See
https://github.com/joyent/node/wiki/API-changes-between-v0.4-and-v0.6.
- Don't use require.paths, as it's no longer mutable.
- Don't use process.binding('stdio'), as it was private and has been removed.

Note that no effort has been made to address #24, this is just to get up
and running with node 0.6.
