### PR TITLE
Replaced hashlib with crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Requirements
 ----------------------------
 
 * [Node.js](http://nodejs.org/) >=0.4.4
-* [Hashlib](https://github.com/brainfucker/hashlib) >=1.0.0
 
 Installation
 ----------------------------
@@ -18,8 +17,6 @@ Installation
 To install, use [npm](http://npmjs.org/):
 
 	npm install webshell
-
-This will install Hashlib as well, if necessary.
 
 Simple HTTP requests
 --------------------

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "url": "https://github.com/fictivekin/webshell.git"
   },
   "engines": { "node": ">=0.4.0" },
-  "dependencies": { "hashlib": ">=1.0.0", "qs": "" },
+  "dependencies": { "qs": "" },
   "bin": { "webshell": "./shell.js" }
 }

--- a/wshttp.js
+++ b/wshttp.js
@@ -9,7 +9,7 @@ var _ = require('./underscore')._,
     cookies = require('./cookies'),
     stylize = require('./colors').stylize,
     querystring = require('qs'),
-    hashlib = require('hashlib'),
+    crypto = require('crypto'),
     wsutil = require('./wsutil');
 
 var failCount = 0;
@@ -389,8 +389,8 @@ WsHttp.prototype = {
       while (nc.length < 8) {
         nc = "0" + nc;
       }
-
-      HA2 = hashlib.md5(HA2);
+        
+      HA2 = crypto.createHash('md5').update(HA2).digest('hex');
 
       /* Calculate middle portion of undigested 'response' */
       var middle = digestPersistent.nonce;
@@ -400,7 +400,7 @@ WsHttp.prototype = {
 
       /* Digest the response. */
       var response = digestPersistent.HA1 + ":" + middle + ":" + HA2;
-      response = hashlib.md5(response);
+      response = crypto.createHash('md5').update(response).digest('hex');
 
       /* Assemble the header value. */
       var hdrVal = "Digest username=\"" + user
@@ -464,7 +464,7 @@ WsHttp.prototype = {
     } else {
       // Initialize HA1
       digestPersistent.HA1 = user + ":" + digestPersistent.realm + ":" + pass;
-      digestPersistent.HA1 = hashlib.md5(digestPersistent.HA1);
+      digestPersistent.HA1 = crypto.createHash('md5').update(digestPersistent.HA1).digest('hex');
     }
 
     // HACK FIXME Just dropping back to auth!


### PR DESCRIPTION
The current version of hashlib in npm doesn't compiled with node 0.6.x. 
